### PR TITLE
Add container support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,17 @@
+FROM docker.io/alpine:latest
+
+ENV FROM_TOKEN=
+ENV TO_TOKEN=
+ENV MIRROR_TOKEN=
+
+RUN apk add git uv
+RUN mkdir -p /usr/src
+
+WORKDIR /usr/src
+COPY . .
+
+RUN uv build --all-packages && uv run --compile-bytecode forgesync || true 
+RUN echo 'uv run --no-sync --directory /usr/src/ forgesync' > /usr/bin/forgesync && chmod +x /usr/bin/forgesync
+
+ENTRYPOINT /usr/bin/forgesync
+

--- a/Containerfile
+++ b/Containerfile
@@ -13,5 +13,5 @@ COPY . .
 RUN uv build --all-packages && uv run --compile-bytecode forgesync || true 
 RUN echo -e  '#!/bin/sh\n\nuv run --no-sync --directory /usr/src/ forgesync $@' > /usr/bin/forgesync && chmod +x /usr/bin/forgesync
 
-ENTRYPOINT /usr/bin/forgesync
+ENTRYPOINT ["/usr/bin/forgesync"]
 

--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src
 COPY . .
 
 RUN uv build --all-packages && uv run --compile-bytecode forgesync || true 
-RUN echo 'uv run --no-sync --directory /usr/src/ forgesync' > /usr/bin/forgesync && chmod +x /usr/bin/forgesync
+RUN echo -e  '#!/bin/sh\n\nuv run --no-sync --directory /usr/src/ forgesync $@' > /usr/bin/forgesync && chmod +x /usr/bin/forgesync
 
 ENTRYPOINT /usr/bin/forgesync
 

--- a/Containerfile
+++ b/Containerfile
@@ -4,13 +4,13 @@ ENV FROM_TOKEN=
 ENV TO_TOKEN=
 ENV MIRROR_TOKEN=
 
-RUN apk add git uv
+RUN apk add uv
 RUN mkdir -p /usr/src
 
 WORKDIR /usr/src
 COPY . .
 
-RUN uv build --all-packages && uv run --compile-bytecode forgesync || true 
+RUN uv build --all-packages && uv sync --compile-bytecode 
 RUN echo -e  '#!/bin/sh\n\nuv run --no-sync --directory /usr/src/ forgesync $@' > /usr/bin/forgesync && chmod +x /usr/bin/forgesync
 
 ENTRYPOINT ["/usr/bin/forgesync"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,39 @@ forgesync \
   --log INFO
 ```
 
+## 📦 Container usage
+
+Alternatively, forgesync can also be ran in a container with podman, docker, kubernetes, etc.
+
+### Building the container
+
+Build with your favorite image building tool (podman, buildah, docker, etc.):
+
+```
+podman build -t localhost/forgesync .
+```
+
+### Running the container
+
+The FROM_TOKEN, TO_TOKEN, and MIRROR_TOKEN tokens must be passed to the container at run-time (`-e` for podman/docker, or as a Kubernetes secret).
+
+Example with podman:
+
+```
+podman run --rm -it \
+  -e FROM_TOKEN=my_forgejo_token \
+  -e TO_TOKEN=my_github_token \
+  -e MIRROR_TOKEN=my_github_mirror_roken \
+  localhost/forgesync \
+    --from-instance https://codeberg.org/api/v1 \
+    --to github \
+    --to-instance https://api.github.com \
+    --remirror \
+    --mirror-interval 8h0m0s \
+    --immediate \
+    --log INFO
+```
+
 ## ❄️ Usage as a NixOS module
 
 Not yet.


### PR DESCRIPTION
This PR includes a Containerfile and documentation in the README for running forgesync in a container (eg, podman, docker, kubernetes).  This could be useful for those who aren't familiar with nix, uv, or otherwise might want to run this as a Kubernetes Job/CronJob, etc.  The environment variables are specified in the Containerfile as a further clue in case it might make deployment more obvious in a UI like podman-desktop, OpenShift, Rancher, etc.