### PR TITLE
Handle pagination when fetching forgejo repos

### DIFF
--- a/src/forgesync/cli.py
+++ b/src/forgesync/cli.py
@@ -20,6 +20,7 @@ from .sync import (
     SyncError,
 )
 from .mirror import MirrorError, PushMirrorConfig, PushMirrorer, Remirror
+from .forgejo import fetch_all_forgejo_repos
 
 
 class ArgumentParser(Tap):
@@ -132,7 +133,8 @@ def main() -> None:
         logger.fatal("Could not get username from Forgejo")
         exit(1)
 
-    real_repos = source_client.user.list_repos(source_user.login)
+    real_repos = list(fetch_all_forgejo_repos(source_client, source_user.login))
+
     source_repos: list[SourceRepository] = []
     for real in real_repos:
         source_repos.append(SourceRepository(real=real))

--- a/src/forgesync/forgejo.py
+++ b/src/forgesync/forgejo.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+import itertools
 from logging import Logger
 from typing import Self, override
 from pyforgejo import PyforgejoApi, Repository as ForgejoRepository, User as ForgejoUser
@@ -12,6 +14,16 @@ from .sync import (
     SyncedRepository,
     Syncer,
 )
+
+
+def fetch_all_forgejo_repos(
+    client: PyforgejoApi, login: str
+) -> Generator[ForgejoRepository, None, None]:
+    for page in itertools.count(1):
+        repos = client.user.list_repos(login, page=page)
+        if not repos:
+            break
+        yield from repos
 
 
 class ForgejoSyncer(Syncer):
@@ -38,7 +50,7 @@ class ForgejoSyncer(Syncer):
             raise SyncError("Could not get username from Forgejo")
 
         self.repos = {}
-        for repo in self.client.user.list_repos(self.user.login):
+        for repo in fetch_all_forgejo_repos(self.client, self.user.login):
             if repo.name is None:
                 continue
             self.repos[repo.name] = repo


### PR DESCRIPTION
From my admittedly brief testing, the initial forgejo repo fetching did not handle pagination and so wouldn't actually list all of my repositories. This seems to be working correctly now when ran with --dry-run.