### PR TITLE
Add support for --org flag syncs

### DIFF
--- a/src/forgesync/cli.py
+++ b/src/forgesync/cli.py
@@ -30,6 +30,8 @@ class ArgumentParser(Tap):
     "base URL of the source instance"
     target: Destination
     "the destination, e.g. github, codeberg or forgejo=https://forgejo.example.com/api/v1"
+    org: str | None = None
+    "the organizaion namespace to sync instead of the user account"
     description_template: str = "{description} (Mirror of {url})"
     "the repository description template"
     remirror: bool = False
@@ -132,14 +134,19 @@ def main() -> None:
         logger=logger,
         push_mirrorer=push_mirrorer,
         push_mirror_config=push_mirror_config,
+        org=args.org,
     )
 
-    source_user = source_client.user.get_current()
-    if source_user.login is None:
-        logger.fatal("Could not get username from Forgejo")
-        exit(1)
+    if args.org:
+        logger.info("Fetching source repositories from organization: %s", args.org)
+        real_repos = depaginate(source_client.organization.org_list_repos, args.org)
+    else:
+        source_user = source_client.user.get_current()
+        if source_user.login is None:
+            logger.fatal("Could not get username from Forgejo")
+            exit(1)
+        real_repos = depaginate(source_client.user.list_repos, source_user.login)
 
-    real_repos = depaginate(source_client.user.list_repos, source_user.login)
     source_repos: list[SourceRepository] = []
     for real in real_repos:
         source_repos.append(SourceRepository(real=real))

--- a/src/forgesync/dest.py
+++ b/src/forgesync/dest.py
@@ -49,6 +49,7 @@ class Destination:
         logger: Logger,
         push_mirrorer: PushMirrorer,
         push_mirror_config: PushMirrorConfig,
+        org: str | None = None,
     ) -> Syncer:
         match self.platform:
             case Platform.GITHUB:
@@ -66,6 +67,7 @@ class Destination:
                     token=token,
                     features=features,
                     logger=logger,
+                    org=org,
                 )
 
     @override

--- a/src/forgesync/forgejo.py
+++ b/src/forgesync/forgejo.py
@@ -52,23 +52,34 @@ class ForgejoSyncer(Syncer):
         token: str,
         features: list[RepositoryFeature],
         logger: Logger,
+        org: str | None = None
     ) -> None:
-        self.client = PyforgejoApi(base_url=instance, api_key=token)
 
-        self.user = self.client.user.get_current()
+        self.client = PyforgejoApi(base_url=instance, api_key=token)
 
         self.features = features
 
-        if self.user.login is None:
-            raise SyncError("Could not get username from Forgejo")
+        self.logger = logger
+
+        self.is_org = bool(org)
 
         self.repos = {}
-        for repo in depaginate(self.client.user.list_repos, self.user.login):
-            if repo.name is None:
-                continue
-            self.repos[repo.name] = repo
-
-        self.logger = logger
+        if self.is_org:
+            self.target_owner = org
+            self.user = None
+            for repo in depaginate(self.client.organization.org_list_repos, self.target_owner):
+                if repo.name is None:
+                    continue
+                self.repos[repo.name] = repo
+        else:
+            self.user = self.client.user.get_current()
+            if self.user.login is None:
+                raise SyncError("Could not get username from Forgejo")
+            self.target_owner = self.user.login
+            for repo in depaginate(self.client.user.list_repos, self.target_owner):
+                if repo.name is None:
+                    continue
+                self.repos[repo.name] = repo
 
     @override
     def sync(
@@ -77,10 +88,7 @@ class ForgejoSyncer(Syncer):
         description: str,
         topics: list[str],
     ) -> SyncedRepository:
-        if self.user.login is None:
-            raise SyncError("Cannot get username from Forgejo")
-
-        self.logger.info("Synchronizing to %s/%s", self.user.login, source_repo.name)
+        self.logger.info("Synchronizing to %s/%s", self.target_owner, source_repo.name)
 
         real = source_repo.real
 
@@ -93,18 +101,28 @@ class ForgejoSyncer(Syncer):
             if existing_repo.fork:
                 raise RepositorySkippedError("Destination repository is a fork")
         else:
-            new_repo = self.client.repository.create_current_user_repo(
-                name=source_repo.name,
-                auto_init=False,
-                default_branch=real.default_branch,
-                description=description,
-                private=real.private,
-            )
+            if self.is_org:
+                new_repo = self.client.organization.create_org_repo(
+                    org=self.target_owner,
+                    name=source_repo.name,
+                    auto_init=False,
+                    default_branch=real.default_branch,
+                    description=description,
+                    private=real.private,
+                )
+            else:
+                new_repo = self.client.repository.create_current_user_repo(
+                    name=source_repo.name,
+                    auto_init=False,
+                    default_branch=real.default_branch,
+                    description=description,
+                    private=real.private,
+                )
 
             self.logger.info("Created new Forgejo repository %s", new_repo.full_name)
 
         edited_repo = self.client.repository.repo_edit(
-            owner=self.user.login,
+            owner=self.target_owner,
             repo=source_repo.name,
             archived=real.archived,
             default_branch=real.default_branch,


### PR DESCRIPTION
Resolves #5 


I'm currently using this to sync from forgejo -> forgejo but I haven't done any other testing with the code. It should still work as normal with no changes, but the `--org` flag will require that the token permissions have access to read/write for the org field (similar to the current `user` requirement) 

This PR also doesn't update any of the docs, but I figured that might need to be done with a new release version. 