### PR TITLE
Bump ENV to match new docs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 FROM docker.io/alpine:latest
 
-ENV FROM_TOKEN=
-ENV TO_TOKEN=
+ENV SOURCE_TOKEN=
+ENV TARGET_TOKEN=
 ENV MIRROR_TOKEN=
 
 RUN apk add uv


### PR DESCRIPTION
I think there was a minor update and this just matches what's documented in the README. 